### PR TITLE
fixed - navigating back to Categories page scroll

### DIFF
--- a/src/app/modules/menu/categories/categories.component.ts
+++ b/src/app/modules/menu/categories/categories.component.ts
@@ -507,17 +507,17 @@ export class CategoriesComponent implements OnInit {
 	}
 
 	ngAfterViewInit() {
-		let catInd = localStorage.getItem('catIndex');
-		console.log("catInx...............", catInd)
-		if (catInd) {
-			if (Number(catInd) > 0) {
-				let ids = Number(catInd) - 1;
-				let idscr = 'scrollTo' + ids;
-				let scr_element = document.getElementById(idscr);
-				scr_element.scrollIntoView();
-			}
-			// {behavior: "smooth", block: "start", inline: "nearest"}
-		}
+		// let catInd = localStorage.getItem('catIndex');
+		// console.log("catInx...............", catInd)
+		// if (catInd) {
+		// 	if (Number(catInd) > 0) {
+		// 		let ids = Number(catInd) - 1;
+		// 		let idscr = 'scrollTo' + ids;
+		// 		let scr_element = document.getElementById(idscr);
+		// 		scr_element.scrollIntoView();
+		// 	}
+		// 	// {behavior: "smooth", block: "start", inline: "nearest"}
+		// }
 	}
 	newCategory() {
 		this.restaurantDetails.menu_category.filter((i) => {


### PR DESCRIPTION
**Bug**
 - When navigating back to the Categories page from Menu Item Page, the scroll position is maintained at the bottom
 
 **Fixed**
- Back to the Categories page, scroll position to top